### PR TITLE
HttpResponse Header info is now placed inside DTOs

### DIFF
--- a/src/test/java/com/sparta/badgerBytes/testFramework/model/dto/SuperDTO.java
+++ b/src/test/java/com/sparta/badgerBytes/testFramework/model/dto/SuperDTO.java
@@ -2,11 +2,50 @@ package com.sparta.badgerBytes.testFramework.model.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.List;
+import java.util.Map;
+
 public class SuperDTO {
 
     @JsonProperty("responseCode")
-    private String responseCode;
+    private Integer responseCode;
 
     @JsonProperty("message")
     private String message;
+
+    private Integer statusCode;
+
+    private Map<String, List<String>> headerProperties;
+
+    public void setResponseCode(Integer responseCode){
+        this.responseCode = responseCode;
+    }
+
+    public void setStatusCode(Integer statusCode){
+        this.statusCode = statusCode;
+    }
+
+    public void setHeaderProperties(Map<String, List<String>> headerProperties){
+        this.headerProperties = headerProperties;
+    }
+
+    public void setMessage(String message){
+        this.message = message;
+    }
+
+    public Integer getResponseCode() {
+        return responseCode;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public Integer getStatusCode() {
+        return statusCode;
+    }
+
+    public Map<String, List<String>> getHeaderProperties() {
+        return headerProperties;
+    }
 }


### PR DESCRIPTION
Status code is in DTOs now along with the rest of the header information. can call getHeaderProperties(); on a DTO to get Map<String, List<String>> can call getStatusCode(); on a DTO to get the Integer status code the responseCode is now an Integer

the Injector deserialize() method is now limited to only accept objects that are either SuperDTO or subclasses of SuperDTO, which also means that the deserialize() method will return SuperDTO (which can then be cast to the specific DTO you want).