### PR TITLE
Added helper methods for getting header values from key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,8 @@
 *.tar.gz
 *.rar
 
+#mac
+.DS_Store
+
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*

--- a/src/test/java/com/sparta/badgerBytes/testFramework/model/dto/SuperDTO.java
+++ b/src/test/java/com/sparta/badgerBytes/testFramework/model/dto/SuperDTO.java
@@ -47,4 +47,15 @@ public class SuperDTO {
     public Map<String, List<String>> getHeaderProperties() {
         return headerProperties;
     }
+
+    public String getHeaderPropertyAsString(String key){
+        StringBuilder property = new StringBuilder();
+        List<String> values = headerProperties.get(key);
+        for(String value : values) property.append(value);
+        return property.toString();
+    }
+
+    public List<String> getHeaderPropertyAsList(String key){
+        return headerProperties.get(key);
+    }
 }


### PR DESCRIPTION
The following method will concatenate the String(s) from the List of a header property to return a single string
public String getHeaderPropertyAsString(String key);

The following method will return the List<String> that is the value of the header property public List<String> getHeaderPropertyAsList(String key);

I also added .DS_Store to .gitignore