### PR TITLE
Smoothing out driver issues (Hopefully :P)

### DIFF
--- a/src/test/java/com/sparta/badgerBytes/webTesting/pom/util/DriverFactory.java
+++ b/src/test/java/com/sparta/badgerBytes/webTesting/pom/util/DriverFactory.java
@@ -6,6 +6,7 @@ import org.openqa.selenium.chrome.ChromeDriverService;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.firefox.*;
 import org.openqa.selenium.safari.SafariDriver;
+import org.openqa.selenium.safari.SafariOptions;
 
 import java.io.*;
 import java.util.Properties;
@@ -14,18 +15,26 @@ public class DriverFactory {
     public static WebDriver getDriver() {
         WebDriver driver = null;
         Properties properties = new Properties();
+
         try {
             properties.load(new FileReader(new File("src/test/resources/webTesting.properties")));
+            boolean headless = properties.get("headless").equals("true");
             switch (properties.getProperty("driver")) {
                 case "chrome":
                     ChromeDriverService service = WebAutomationUtil.getChromeDriverService(properties.getProperty("driverPath"));
                     ChromeOptions options = new ChromeOptions();
                     options.addArguments("--remote-allow-origins=*");
-                    //options.addArguments("headless");
+                    if(headless) options.addArguments("headless");
                     driver = new ChromeDriver(service, options);
                     break;
                 case "firefox":
                     System.setProperty("webdriver.gecko.driver", properties.getProperty("driverPath"));
+                    if(headless) {
+                        FirefoxOptions ffoptions = new FirefoxOptions();
+                        ffoptions.addArguments("-headless");
+                        driver = new FirefoxDriver(ffoptions);
+                        break;
+                    }
                     driver = new FirefoxDriver();
                     break;
                 case "safari":

--- a/src/test/java/com/sparta/badgerBytes/webTesting/pom/util/DriverFactory.java
+++ b/src/test/java/com/sparta/badgerBytes/webTesting/pom/util/DriverFactory.java
@@ -1,0 +1,42 @@
+package com.sparta.badgerBytes.webTesting.pom.util;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeDriverService;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.firefox.*;
+import org.openqa.selenium.safari.SafariDriver;
+
+import java.io.*;
+import java.util.Properties;
+
+public class DriverFactory {
+    public static WebDriver getDriver() {
+        WebDriver driver = null;
+        Properties properties = new Properties();
+        try {
+            properties.load(new FileReader(new File("src/test/resources/webTesting.properties")));
+            switch (properties.getProperty("driver")) {
+                case "chrome":
+                    ChromeDriverService service = WebAutomationUtil.getChromeDriverService(properties.getProperty("driverPath"));
+                    ChromeOptions options = new ChromeOptions();
+                    options.addArguments("--remote-allow-origins=*");
+                    //options.addArguments("headless");
+                    driver = new ChromeDriver(service, options);
+                    break;
+                case "firefox":
+                    System.setProperty("webdriver.gecko.driver", properties.getProperty("driverPath"));
+                    driver = new FirefoxDriver();
+                    break;
+                case "safari":
+                    driver = new SafariDriver();
+            }
+            return driver;
+        }catch(Exception e){
+            e.printStackTrace();
+            System.out.println("There was an issue loading from the properties file or starting your web driver");
+            System.out.println("Please ensure you have the correct properties settings and drivers");
+            return null;
+        }
+    }
+}

--- a/src/test/resources/webTesting.properties
+++ b/src/test/resources/webTesting.properties
@@ -1,0 +1,25 @@
+#****************************************#
+# for use with DriverFactory.getDriver() #
+#****************************************#
+#Making use of the above named method we #
+#    can ensure that the driver can be   #
+# swapped out at the tester's discretion #
+#****************************************#
+
+#uncomment ONE of the following
+#driver=firefox
+#driver=chrome
+#driver=safari
+
+
+#driver path MAC options
+
+#driverPath=src/test/resources/geckodriver
+#driverPath=src/test/resources/chromedriver
+
+#driver path WINDOWS options
+
+#driverPath=src/test/resources/geckodriver.exe
+#driverPath=src/test/resources/chromedriver.exe
+
+

--- a/src/test/resources/webTesting.properties
+++ b/src/test/resources/webTesting.properties
@@ -6,10 +6,13 @@
 # swapped out at the tester's discretion #
 #****************************************#
 
+headless=false
+
 #uncomment ONE of the following
 #driver=firefox
 #driver=chrome
 #driver=safari
+
 
 
 #driver path MAC options


### PR DESCRIPTION
DriverFactory class made
Please forgive the branch name, that is no longer the goal of this branch.
There is now a DriverFactory static method getDriver() that you should be able to call
that will take input from the webTesting.properties file to get you the driver you need.
This feature currently only supports chrome, firefox, and safari. You do not need a driver
executable on mac for the Safari browser.

Please when closing the driver returned from this method only use the quit() method.
The quit method will close the driver and any browser windows opened by the driver.
using both quit() and exit() can throw an exception and cause your tests to fail.

This feature has currently ONLY been tested on mac, so I still need a windows user to
verify that it will work correctly in that environment (should do hopefully? xD)

If there is any issue with creating the driver itself then getDriver() method will
return null and print an error message to the console.

headless property in the new property file will allow you to start the tests without opening up a visible GUI for the chrome and firefox browsers