### PR TITLE
Test cases 7 and 19

### DIFF
--- a/src/test/java/com/sparta/badgerBytes/webTesting/cucumber/stepdefs/BrandNavigationStepDef.java
+++ b/src/test/java/com/sparta/badgerBytes/webTesting/cucumber/stepdefs/BrandNavigationStepDef.java
@@ -1,0 +1,71 @@
+package com.sparta.badgerBytes.webTesting.cucumber.stepdefs;
+
+import com.sparta.badgerBytes.webTesting.pom.pages.BrandProductPage;
+import com.sparta.badgerBytes.webTesting.pom.pages.HomePage;
+import com.sparta.badgerBytes.webTesting.pom.util.DriverFactory;
+import io.cucumber.java.en.And;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import org.openqa.selenium.WebDriver;
+
+import java.sql.Driver;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class BrandNavigationStepDef {
+    HomePage homePage;
+    BrandProductPage brandProductPage;
+    WebDriver driver;
+    @Given("I am on the home page")
+    public void iAmOnTheHomePage() {
+        driver = DriverFactory.getDriver();
+        homePage = new HomePage(driver);
+    }
+
+    @When("I click on the KOOKIE KIDS button")
+    public void iClickOnTheKOOKIEKIDSButton() {
+        brandProductPage = homePage.goToBrandPage("KOOKIE KIDS");
+    }
+
+    @Then("I should be directed to the Kookie Kids product page")
+    public void iShouldBeDirectedToTheKookieKidsProductPage() {
+        assertEquals("https://automationexercise.com/brand_products/Kookie%20Kids", brandProductPage.getUrl());
+    }
+
+    @And("I should see all of the KOOKIE KIDS products")
+    public void iShouldSeeAllOfTheKOOKIEKIDSProducts() {
+        assertEquals("BRAND - KOOKIE KIDS PRODUCTS", brandProductPage.getBrandProductListTitle());
+        assertEquals(brandProductPage.getExpectedBrandProductsCount(), brandProductPage.getBrandProductsCount());
+        driver.close();
+    }
+
+    @Given("I am on the Kookie Kids product page")
+    public void iAmOnTheKookieKidsProductPage() {
+        //new given makes me do the setup again :P
+        driver = DriverFactory.getDriver();
+        homePage = new HomePage(driver);
+        brandProductPage = homePage.goToBrandPage("KOOKIE KIDS");
+    }
+
+    @When("I click on the BABYHUG button")
+    public void iClickOnTheBABYHUGButton() {
+        brandProductPage = brandProductPage.goToBrandPage("BABYHUG");
+    }
+
+    @Then("I should be directed to the Babyhug products page")
+    public void iShouldBeDirectedToTheBabyhugProductsPage() {
+        assertEquals("https://automationexercise.com/brand_products/Babyhug", brandProductPage.getUrl());
+    }
+
+    @And("I should see all of the Babyhug products")
+    public void iShouldSeeAllOfTheBabyhugProducts() {
+        assertEquals("BRAND - BABYHUG PRODUCTS", brandProductPage.getBrandProductListTitle());
+        assertEquals(brandProductPage.getExpectedBrandProductsCount(), brandProductPage.getBrandProductsCount());
+        driver.close();
+    }
+
+
+
+}

--- a/src/test/java/com/sparta/badgerBytes/webTesting/cucumber/stepdefs/StepDefNavigateToTestCasesPage.java
+++ b/src/test/java/com/sparta/badgerBytes/webTesting/cucumber/stepdefs/StepDefNavigateToTestCasesPage.java
@@ -1,0 +1,41 @@
+package com.sparta.badgerBytes.webTesting.cucumber.stepdefs;
+
+import com.sparta.badgerBytes.webTesting.pom.pages.HomePage;
+import com.sparta.badgerBytes.webTesting.pom.pages.TestCasesPage;
+import com.sparta.badgerBytes.webTesting.pom.util.DriverFactory;
+import io.cucumber.java.Before;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import org.junit.After;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class StepDefNavigateToTestCasesPage {
+    private static WebDriver webDriver;
+    private static HomePage homePage;
+
+    private static TestCasesPage testCasesPage;
+
+    @Given("I am on the homepage")
+    public void iAmOnTheHomepage() {
+        webDriver = DriverFactory.getDriver();
+        homePage = new HomePage(webDriver);
+    }
+
+    @When("I click the Test Cases button")
+    public void iClickTheTestCasesButton() {
+        testCasesPage = homePage.goToTestCasesPage();
+    }
+
+    @Then("I should be directed to the test_cases page")
+    public void iShouldBeDirectedToTheTest_casesPage() {
+        assertEquals("https://automationexercise.com/test_cases", testCasesPage.getUrl());
+        webDriver.close();
+        webDriver.quit();
+    }
+
+
+}

--- a/src/test/java/com/sparta/badgerBytes/webTesting/pom/pages/BrandProductPage.java
+++ b/src/test/java/com/sparta/badgerBytes/webTesting/pom/pages/BrandProductPage.java
@@ -1,0 +1,38 @@
+package com.sparta.badgerBytes.webTesting.pom.pages;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+
+public class BrandProductPage {
+    private static WebDriver driver;
+    public BrandProductPage(WebDriver webDriver) {
+        this.driver = webDriver;
+    }
+
+    public BrandProductPage goToBrandPage(String brandName){
+        driver.findElement(By.partialLinkText(brandName.toUpperCase())).click();
+        return new BrandProductPage(driver);
+    }
+
+    public String getUrl(){
+        return driver.getCurrentUrl();
+    }
+
+    public String getBrandProductListTitle(){
+        return driver.findElement(By.cssSelector(".features_items > .text-center")).getText();
+    }
+
+    public int getBrandProductsCount(){
+        return driver.findElements(By.cssSelector(".features_items .single-products")).size();
+    }
+
+    public int getExpectedBrandProductsCount(){
+        String[] brandLinkSegments = getUrl().split("/");
+        String brandLink = "/" + brandLinkSegments[brandLinkSegments.length - 1];
+        brandLink = brandLink.replaceAll("%20", " ");
+        return Integer.parseInt(
+                driver.findElement(
+                By.cssSelector("a[href='/brand_products" + brandLink + "'] .pull-right"))
+                .getText().replaceAll("[()]", ""));
+    }
+}

--- a/src/test/java/com/sparta/badgerBytes/webTesting/pom/pages/HomePage.java
+++ b/src/test/java/com/sparta/badgerBytes/webTesting/pom/pages/HomePage.java
@@ -17,10 +17,20 @@ public class HomePage {
     driver.get("https://automationexercise.com/");
   }
 
+  public BrandProductPage goToBrandPage(String brandName){
+    driver.findElement(By.partialLinkText(brandName.toUpperCase())).click();
+    return new BrandProductPage(driver);
+  }
+
   public Cart goToCartPage(){
 
     driver.findElement(By.linkText("Cart")).click();
     return new Cart(driver);
+  }
+
+  public TestCasesPage goToTestCasesPage(){
+    driver.findElement(By.cssSelector(".test_cases_list")).click();
+    return new TestCasesPage(driver);
   }
 
   public void clickContinueShopping(){ driver.findElement(By.cssSelector("button.btn.btn-success.close-modal.btn-block")).click();}

--- a/src/test/java/com/sparta/badgerBytes/webTesting/pom/pages/TestCasesPage.java
+++ b/src/test/java/com/sparta/badgerBytes/webTesting/pom/pages/TestCasesPage.java
@@ -1,0 +1,16 @@
+package com.sparta.badgerBytes.webTesting.pom.pages;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+public class TestCasesPage {
+    private static WebDriver driver;
+    public TestCasesPage(WebDriver webDriver) {
+        this.driver = webDriver;
+    }
+
+    public String getUrl(){
+        return driver.getCurrentUrl();
+    }
+}

--- a/src/test/resources/features/BrandProductsSideBarNav.feature
+++ b/src/test/resources/features/BrandProductsSideBarNav.feature
@@ -1,0 +1,13 @@
+Feature: As a tester I WANT to be able to access individual brand product pages
+
+  Scenario: verification of brand side bar feature from home page
+    Given I am on the home page
+    When I click on the KOOKIE KIDS button
+    Then I should be directed to the Kookie Kids product page
+    And I should see all of the KOOKIE KIDS products
+
+  Scenario: verification of brand side bar feature from a specific brand product page
+    Given I am on the Kookie Kids product page
+    When I click on the BABYHUG button
+    Then I should be directed to the Babyhug products page
+    And I should see all of the Babyhug products

--- a/src/test/resources/features/navigateToTestCasesPage.feature
+++ b/src/test/resources/features/navigateToTestCasesPage.feature
@@ -1,0 +1,5 @@
+Feature: As a tester I WANT to be able to navigate to the Test Cases page
+  Scenario: I navigate to the Test Cases page
+    Given I am on the homepage
+    When I click the Test Cases button
+    Then I should be directed to the test_cases page


### PR DESCRIPTION
HomePage modified. Also it appears because my BrandProductsSideBarNav.feature has 2 Scenarios and 2 Givens that I essentially had to build up the given again rather than continuing from the previously defined properties which is fine and it works, just >;v

A bigger thing to note is that the only way I have found to successfully avoid issues with the ad that covers the whole browser window would be to run in headless mode. All tests pass in headless mode, but not otherwise which I mean it's not ideal, but it's what I got until we find another way to handle those pesky advertisements.